### PR TITLE
Close #19: Verbose flag

### DIFF
--- a/src/cert/mod.rs
+++ b/src/cert/mod.rs
@@ -46,6 +46,30 @@ impl CertInfo {
     }
 }
 
+#[derive(Debug, Clone, Serialize)]
+pub struct VerboseCert {
+    pub base_cert: CertInfo,
+    pub key_usage: String,
+    // extended key usage
+    require_explicit_policy: String,
+    inhibit_policy_mapping: String
+    
+}
+
+impl VerboseCert {
+    pub fn days_remaining(&self) -> i64 {
+        self.base_cert.days_remaining()
+    }
+
+    pub fn is_expired(&self) -> bool {
+        self.base_cert.is_expired()
+    }
+
+    pub fn key_description(&self) -> String {
+        self.base_cert.key_description()
+    }
+}
+
 /// Key algorithm type
 #[derive(Debug, Clone, Serialize)]
 pub enum KeyType {

--- a/src/cert/mod.rs
+++ b/src/cert/mod.rs
@@ -2,8 +2,8 @@ pub mod chain;
 pub mod parser;
 pub mod tls;
 
-use std::collections::HashMap;
 use serde::Serialize;
+use std::collections::HashMap;
 use std::fmt;
 use std::time::{SystemTime, UNIX_EPOCH};
 
@@ -49,20 +49,15 @@ impl CertInfo {
 
 pub struct VerboseCert {
     pub base_cert: CertInfo,
-    pub extensions: HashMap<String, Vec<(String, String)>>
+    pub extensions: HashMap<String, Vec<(String, String)>>,
 }
 
+// This could be implemented using a trait, however this would require some refactoring
 impl VerboseCert {
-    pub fn days_remaining(&self) -> i64 {
-        self.base_cert.days_remaining()
-    }
+    // Days remaining and key description removed to keep clippy clean
 
     pub fn is_expired(&self) -> bool {
         self.base_cert.is_expired()
-    }
-
-    pub fn key_description(&self) -> String {
-        self.base_cert.key_description()
     }
 }
 

--- a/src/cert/mod.rs
+++ b/src/cert/mod.rs
@@ -47,10 +47,9 @@ impl CertInfo {
     }
 }
 
-#[derive(Debug, Clone, Serialize)]
 pub struct VerboseCert {
     pub base_cert: CertInfo,
-    pub extensions: HashMap<String, String>
+    pub extensions: HashMap<String, Vec<(String, String)>>
 }
 
 impl VerboseCert {

--- a/src/cert/mod.rs
+++ b/src/cert/mod.rs
@@ -2,6 +2,7 @@ pub mod chain;
 pub mod parser;
 pub mod tls;
 
+use std::collections::HashMap;
 use serde::Serialize;
 use std::fmt;
 use std::time::{SystemTime, UNIX_EPOCH};
@@ -49,11 +50,7 @@ impl CertInfo {
 #[derive(Debug, Clone, Serialize)]
 pub struct VerboseCert {
     pub base_cert: CertInfo,
-    pub key_usage: String,
-    // extended key usage
-    require_explicit_policy: String,
-    inhibit_policy_mapping: String
-    
+    pub extensions: HashMap<String, String>
 }
 
 impl VerboseCert {

--- a/src/cert/parser.rs
+++ b/src/cert/parser.rs
@@ -2,7 +2,7 @@ use anyhow::{bail, Context, Result};
 use x509_parser::prelude::*;
 use x509_parser::public_key::PublicKey;
 
-use crate::cert::{CertInfo, CertTime, KeyType};
+use crate::cert::{CertInfo, CertTime, KeyType, VerboseCert};
 
 /// Format bytes as colon-separated hex
 fn format_hex(bytes: &[u8]) -> String {
@@ -64,9 +64,6 @@ pub fn parse_der_cert(der_data: &[u8]) -> Result<CertInfo> {
     let (_, cert) = X509Certificate::from_der(der_data)
         .map_err(|e| anyhow::anyhow!("bad certificate: {}", e))?;
 
-    // TODO Test prints
-
-
     let subject = cert.subject().to_string();
     let issuer = cert.issuer().to_string();
     let serial_hex = format_hex(cert.raw_serial());
@@ -101,6 +98,56 @@ pub fn parse_der_cert(der_data: &[u8]) -> Result<CertInfo> {
         public_key_sha256,
         is_ca,
         version: cert.version().0,
+    })
+}
+
+fn verbose_parse_der_cert(der_data: &[u8]) -> Result<VerboseCert> {
+    let (_, cert) = X509Certificate::from_der(der_data)
+        .map_err(|e| anyhow::anyhow!("bad certificate: {}", e))?;
+
+    // Key usage
+    let key_usage = cert.key_usage()?;
+    let key_usage = if key_usage.is_some() {
+        key_usage.unwrap().value.to_string()
+    } else {String::from("None")};
+    let extended_key_usage = cert.extended_key_usage()?.unwrap().value; //fixme
+
+    // Policy constraints
+    let policy_constraints = cert.policy_constraints()?;
+    let (require_explicit_policy, inhibit_policy_mapping) = if policy_constraints.is_some() {
+        let p = policy_constraints.unwrap().value;
+        (
+            p.require_explicit_policy.unwrap().to_string(),
+            p.inhibit_policy_mapping.unwrap().to_string()
+        )
+    } else {
+        (String::from("None"), String::from("None"))
+    };
+
+    let inhibit_anypolicy = cert.inhibit_anypolicy()?.unwrap().value;
+
+    // CRLDistributionPoints
+
+
+    /*
+    InhibitAnyPolicy(InhibitAnyPolicy),
+    AuthorityInfoAccess(AuthorityInfoAccess<'a>),
+    SubjectInfoAccess(SubjectInfoAccess<'a>),
+    NSCertType(NSCertType),
+    NsCertComment(&'a str),
+    IssuingDistributionPoint(IssuingDistributionPoint<'a>),
+    CRLNumber(BigUint),
+    ReasonCode(ReasonCode),
+    InvalidityDate(ASN1Time),
+    SCT(Vec<SignedCertificateTimestamp<'a>>),
+     */
+
+    Ok(VerboseCert{
+        base_cert: parse_der_cert(der_data)?,
+        key_usage,
+        extended_key_usage,
+        require_explicit_policy,
+        inhibit_policy_mapping
     })
 }
 

--- a/src/cert/parser.rs
+++ b/src/cert/parser.rs
@@ -189,8 +189,10 @@ fn verbose_parse_der_cert(der_data: &[u8]) -> Result<VerboseCert> {
                     )
                 ].to_vec()
             },
-            ParsedExtension::SubjectKeyIdentifier(subject_key_id) => {
-                [].to_vec()
+            ParsedExtension::SubjectKeyIdentifier(key_id) => {
+                [
+                    ("Subject key id".to_string(), format_hex(key_id.0))
+                ].to_vec()
             },
             ParsedExtension::KeyUsage(key_usage) => {
                 [
@@ -212,25 +214,60 @@ fn verbose_parse_der_cert(der_data: &[u8]) -> Result<VerboseCert> {
                             format!("Policy {}", policy_information.policy_id),
                              match &policy_information.policy_qualifiers {
                                  None => "None".to_string(),
-                                 Some(qualifiers) => "todo".to_string()
+                                 Some(qualifiers) => "todo".to_string() //todo
                              }
                         )
                 }))
             },
             ParsedExtension::PolicyMappings(policy_mappings) => {
-                [].to_vec()
+                [
+                    ("Policy mappings".to_string(), policy_mappings.mappings.iter().map(
+                        |mapping| {
+                        format!(
+                            "(Issuer: {}, Subject: {})",
+                            &mapping.issuer_domain_policy.to_id_string(),
+                            &mapping.subject_domain_policy.to_id_string()
+                        ).to_string() }
+                    ).collect::<Vec<String>>().join(", "))
+                ].to_vec()
             },
             ParsedExtension::SubjectAlternativeName(subject_alt_name) => {
-                [].to_vec()
+                [
+                    ("Subject alternative name(s)".to_string(), format!("{:?}", subject_alt_name.general_names))
+                ].to_vec()
             },
             ParsedExtension::IssuerAlternativeName(issuer_alt_name) => {
-                [].to_vec()
+                [
+                    ("Issuer alternative name(s)".to_string(), format!("{:?}", issuer_alt_name.general_names))
+                ].to_vec()
             },
             ParsedExtension::BasicConstraints(constraints_basic) => {
+                // Handled in CertInfo
                 [].to_vec()
             },
             ParsedExtension::NameConstraints(constraints_name) => {
-                [].to_vec()
+                let format_subtrees =
+                    |subtrees_options:&Option<Vec<GeneralSubtree>>| {
+                    match subtrees_options {
+                        Some(subtrees) => subtrees.iter().map(
+                            |tree| {
+                                tree.base.to_string()
+                            }
+                        ).collect::<Vec<String>>().join(", "),
+                        None => "None".to_string()
+                    }
+                };
+
+                [
+                    (
+                        "Permitted subtrees".to_string(),
+                        format_subtrees(&constraints_name.permitted_subtrees)
+                    ),
+                    (
+                        "Permitted subtrees".to_string(),
+                        format_subtrees(&constraints_name.excluded_subtrees)
+                    )
+                ].to_vec()
             },
             ParsedExtension::PolicyConstraints(constraints_policy) => {
                 [].to_vec()

--- a/src/cert/parser.rs
+++ b/src/cert/parser.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
-use std::io::Read;
 use anyhow::{bail, Context, Result};
+use rustls::internal::msgs::codec::Codec;
 use x509_parser::prelude::*;
 use x509_parser::public_key::PublicKey;
 
@@ -13,6 +13,12 @@ fn format_hex(bytes: &[u8]) -> String {
         .map(|b| format!("{:02X}", b))
         .collect::<Vec<_>>()
         .join(":")
+}
+
+fn format_hex_from_u32(bytes: u32) -> String {
+    let mut buf: Vec<u8> = Vec::new();
+    bytes.encode(&mut buf);
+    format_hex(&*buf)
 }
 
 pub fn parse_cert_file(path: &str) -> Result<Vec<CertInfo>> {
@@ -156,98 +162,133 @@ fn verbose_parse_der_cert(der_data: &[u8]) -> Result<VerboseCert> {
         .map_err(|e| anyhow::anyhow!("bad certificate: {}", e))?;
 
     // Could go to a HashMap<String, [(String,String)]>
-    let mut extensions: HashMap<String, String> = HashMap::new();
+    let mut extensions: HashMap<String, Vec<(String, String)>> = HashMap::new();
 
     for e in cert.iter_extensions() {
-        // List of extensions: https://docs.rs/x509-parser/0.18.1/x509_parser/extensions/enum.ParsedExtension.html
-        extensions.extend(match e.parsed_extension() {
-            ParsedExtension::AuthorityKeyIdentifier(authority_key_id) => {
-                [
+        match parse_der_extension(e) {
+            Some(d) =>{extensions.insert(d.0, d.1);},
+            None => {}
+        }
+    }
+
+    Ok(VerboseCert {
+        base_cert: parse_der_cert(der_data)?,
+        extensions
+    })
+}
+
+fn parse_der_extension(e: &X509Extension) -> Option<(String, Vec<(String, String)>)> {
+    // List of extensions: https://docs.rs/x509-parser/0.18.1/x509_parser/extensions/enum.ParsedExtension.html
+    let interpret_reason_flags = |flags: &ReasonFlags| -> String {
+        format!(
+            "Key compromised: {}, CA compromised: {}, Affiliation changed: {}, Superseded: {}, Cessation of operation: {}, Certificate hold: {}, Privilege withdrawn: {}, AA compromised: {}",
+            flags.key_compromise(),
+            flags.ca_compromise(),
+            flags.affilation_changed(),
+            flags.superseded(),
+            flags.cessation_of_operation(),
+            flags.certificate_hold(),
+            flags.privelege_withdrawn(),
+            flags.aa_compromise()
+        )
+    };
+
+    match e.parsed_extension() {
+        ParsedExtension::AuthorityKeyIdentifier(authority_key_id) => {
+            Some(("Authority key identifier".to_string(), [
+                (
+                    "Key identifier".to_string(),
+                    match &authority_key_id.key_identifier {
+                        None => "None".to_string(),
+                        Some(id) => format_hex(id.0)
+                    }
+                ),
+                (
+                    "Authority cert issuer".to_string(),
+                    match &authority_key_id.authority_cert_issuer {
+                        None => "None".to_string(),
+                        Some(issuer) =>
+                            String::from_iter(
+                                issuer.iter().map(|gn| gn.to_string())
+                            ) //check this
+                    }
+                ),
+                (
+                    "Authority cert serial".to_string(),
+                    match authority_key_id.authority_cert_serial {
+                        None => "None".to_string(),
+                        Some(serial) => format_hex(serial)
+                    }
+                )
+            ].to_vec()))
+        },
+        ParsedExtension::SubjectKeyIdentifier(key_id) => {
+            Some(("Subject key identifier".to_string(), [
+                ("Subject key id".to_string(), format_hex(key_id.0))
+            ].to_vec()))
+        },
+        ParsedExtension::KeyUsage(key_usage) => {
+            Some(("Key usage".to_string(), [
+                ("Digital signature".to_string(), key_usage.digital_signature().to_string()),
+                ("Non repudiation".to_string(), key_usage.non_repudiation().to_string()),
+                ("Key encipherment".to_string(), key_usage.key_encipherment().to_string()),
+                ("Data encipherment".to_string(), key_usage.data_encipherment().to_string()),
+                ("Key agreement".to_string(), key_usage.key_agreement().to_string()),
+                ("Key cert sign".to_string(), key_usage.key_cert_sign().to_string()),
+                ("CRL sign".to_string(), key_usage.key_encipherment().to_string()),
+                ("Encipher only".to_string(), key_usage.key_encipherment().to_string()),
+                ("Decipher only".to_string(), key_usage.key_encipherment().to_string()),
+            ].to_vec()))
+        },
+        ParsedExtension::CertificatePolicies(cert_policies) => {
+            Some(("Certificate policies".to_string(), Vec::from_iter(cert_policies.iter().map(
+                |policy_information| {
                     (
-                        "Authority key identifier".to_string(),
-                         match &authority_key_id.key_identifier {
-                            None => "None".to_string(),
-                            Some(id) => format_hex(id.0)
+                        format!("Policy {}", policy_information.policy_id.to_id_string()),
+
+                        match &policy_information.policy_qualifiers {
+                            Some(qualifiers) =>
+                                qualifiers.iter().map(|pqi| {
+                                    format!(
+                                        "{}: {}",
+                                        pqi.policy_qualifier_id.to_id_string(),
+                                        format_hex(&pqi.qualifier)
+                                    )
+                                }).collect::<Vec<_>>().join(", "),
+                            None => "None".to_string()
                         }
-                    ),
-                    (
-                        "Authority cert issuer".to_string(),
-                         match &authority_key_id.authority_cert_issuer {
-                            None => "None".to_string(),
-                            Some(issuer) =>
-                                String::from_iter(
-                                    issuer.iter().map(|gn| gn.to_string())
-                                ) //check this
-                        }
-                    ),
-                    (
-                        "Authority cert serial".to_string(),
-                         match authority_key_id.authority_cert_serial {
-                             None => "None".to_string(),
-                             Some(serial) => format_hex(serial)
-                         }
                     )
-                ].to_vec()
-            },
-            ParsedExtension::SubjectKeyIdentifier(key_id) => {
-                [
-                    ("Subject key id".to_string(), format_hex(key_id.0))
-                ].to_vec()
-            },
-            ParsedExtension::KeyUsage(key_usage) => {
-                [
-                    ("Digital signature".to_string(), key_usage.digital_signature().to_string()),
-                    ("Non repudiation".to_string(), key_usage.non_repudiation().to_string()),
-                    ("Key encipherment".to_string(), key_usage.key_encipherment().to_string()),
-                    ("Data encipherment".to_string(), key_usage.data_encipherment().to_string()),
-                    ("Key agreement".to_string(), key_usage.key_agreement().to_string()),
-                    ("Key cert sign".to_string(), key_usage.key_cert_sign().to_string()),
-                    ("CRL sign".to_string(), key_usage.key_encipherment().to_string()),
-                    ("Encipher only".to_string(), key_usage.key_encipherment().to_string()),
-                    ("Decipher only".to_string(), key_usage.key_encipherment().to_string()),
-                ].to_vec()
-            },
-            ParsedExtension::CertificatePolicies(cert_policies) => {
-                Vec::from_iter(cert_policies.iter().map(
-                    |policy_information| {
-                        (
-                            format!("Policy {}", policy_information.policy_id),
-                             match &policy_information.policy_qualifiers {
-                                 None => "None".to_string(),
-                                 Some(qualifiers) => "todo".to_string() //todo
-                             }
-                        )
-                }))
-            },
-            ParsedExtension::PolicyMappings(policy_mappings) => {
-                [
-                    ("Policy mappings".to_string(), policy_mappings.mappings.iter().map(
-                        |mapping| {
-                        format!(
-                            "(Issuer: {}, Subject: {})",
-                            &mapping.issuer_domain_policy.to_id_string(),
-                            &mapping.subject_domain_policy.to_id_string()
-                        ).to_string() }
-                    ).collect::<Vec<String>>().join(", "))
-                ].to_vec()
-            },
-            ParsedExtension::SubjectAlternativeName(subject_alt_name) => {
-                [
-                    ("Subject alternative name(s)".to_string(), format!("{:?}", subject_alt_name.general_names))
-                ].to_vec()
-            },
-            ParsedExtension::IssuerAlternativeName(issuer_alt_name) => {
-                [
-                    ("Issuer alternative name(s)".to_string(), format!("{:?}", issuer_alt_name.general_names))
-                ].to_vec()
-            },
-            ParsedExtension::BasicConstraints(constraints_basic) => {
-                // Handled in CertInfo
-                [].to_vec()
-            },
-            ParsedExtension::NameConstraints(constraints_name) => {
-                let format_subtrees =
-                    |subtrees_options:&Option<Vec<GeneralSubtree>>| {
+                }))))
+        },
+        ParsedExtension::PolicyMappings(policy_mappings) => {
+            Some(("Policy mappings".to_string(),
+             policy_mappings.mappings.iter().map(
+                 |mapping| {
+                     (
+                         mapping.issuer_domain_policy.to_id_string(),
+                         mapping.subject_domain_policy.to_id_string()
+                     )
+                 }
+             ).collect::<Vec<(String, String)>>()
+            ))
+        },
+        ParsedExtension::SubjectAlternativeName(subject_alt_name) => {
+            Some(("Subject alternative name".to_string(), [
+                ("Name(s)".to_string(), format!("{:?}", subject_alt_name.general_names))
+            ].to_vec()))
+        },
+        ParsedExtension::IssuerAlternativeName(issuer_alt_name) => {
+            Some(("Issuer alternative name".to_string(), [
+                ("Name(s)".to_string(), format!("{:?}", issuer_alt_name.general_names))
+            ].to_vec()))
+        },
+        ParsedExtension::BasicConstraints(_) => {
+            // Handled in CertInfo
+            None
+        },
+        ParsedExtension::NameConstraints(constraints_name) => {
+            let format_subtrees =
+                |subtrees_options: &Option<Vec<GeneralSubtree>>| {
                     match subtrees_options {
                         Some(subtrees) => subtrees.iter().map(
                             |tree| {
@@ -258,72 +299,203 @@ fn verbose_parse_der_cert(der_data: &[u8]) -> Result<VerboseCert> {
                     }
                 };
 
-                [
-                    (
-                        "Permitted subtrees".to_string(),
-                        format_subtrees(&constraints_name.permitted_subtrees)
-                    ),
-                    (
-                        "Permitted subtrees".to_string(),
-                        format_subtrees(&constraints_name.excluded_subtrees)
-                    )
-                ].to_vec()
-            },
-            ParsedExtension::PolicyConstraints(constraints_policy) => {
-                [].to_vec()
-            },
-            ParsedExtension::ExtendedKeyUsage(extended_key_usage) => {
-                [].to_vec()
-            },
-            ParsedExtension::CRLDistributionPoints(crl_dist_points) => {
-                [].to_vec()
-            },
-            ParsedExtension::InhibitAnyPolicy(policy_inhibit_any) => {
-                [].to_vec()
-            },
-            ParsedExtension::AuthorityInfoAccess(authority_info_access) => {
-                [].to_vec()
-            },
-            ParsedExtension::NSCertType(ns_cert_type) => {
-                [].to_vec()
-            },
-            ParsedExtension::NsCertComment(ns_cert_comment) => {
-                [].to_vec()
-            },
-            ParsedExtension::IssuingDistributionPoint(issuing_dist_point) => {
-                [].to_vec()
-            },
-            ParsedExtension::CRLNumber(crl_num) => {
-                [].to_vec()
-            },
-            ParsedExtension::ReasonCode(reason_code) => {
-                [].to_vec()
-            },
-            ParsedExtension::InvalidityDate(invalidity_date) => {
-                [].to_vec()
-            },
-            ParsedExtension::SCT(sct) => {
-                [].to_vec()
-            },
+            Some(("Name constraints".to_string(), [
+                (
+                    "Permitted subtrees".to_string(),
+                    format_subtrees(&constraints_name.permitted_subtrees)
+                ),
+                (
+                    "Permitted subtrees".to_string(),
+                    format_subtrees(&constraints_name.excluded_subtrees)
+                )
+            ].to_vec()))
+        },
+        ParsedExtension::PolicyConstraints(constraints_policy) => {
+            let format_constraint = |constraint: &Option<u32>| {
+                match constraint {
+                    Some(u) => {
+                        format_hex_from_u32(*u)
+                    },
+                    None => "None".to_string()
+                }
+            };
 
-            ParsedExtension::UnsupportedExtension {oid} => {
-                [("Unsupported extension".to_string(), oid.to_string())].to_vec()
-            },
-            ParsedExtension::ParseError {error} => {
-                [].to_vec()
-            },
-            ParsedExtension::Unparsed => {
-                [].to_vec()
-            },
-            _ => Vec::new()
+            Some(("Policy constraints".to_string(), [
+                (
+                    "Require explicit policy".to_string(),
+                    format_constraint(&constraints_policy.inhibit_policy_mapping)
+                ),
+                (
+                    "Inhibit policy mapping".to_string(),
+                    format_constraint(&constraints_policy.require_explicit_policy)
+                )
+            ].to_vec()))
+        },
+        ParsedExtension::ExtendedKeyUsage(extended_key_usage) => {
+            Some(("Extended key usage".to_string(), [
+                ("Any".to_string(), extended_key_usage.any.to_string()),
+                ("Server authentication".to_string(), extended_key_usage.server_auth.to_string()),
+                ("Client authentication".to_string(), extended_key_usage.client_auth.to_string()),
+                ("Code signing".to_string(), extended_key_usage.code_signing.to_string()),
+                ("Email protection".to_string(), extended_key_usage.email_protection.to_string()),
+                ("Time stamping".to_string(), extended_key_usage.time_stamping.to_string()),
+                ("OCSP signing".to_string(), extended_key_usage.ocsp_signing.to_string()),
+                (
+                    "Other".to_string(),
+                    extended_key_usage.other.iter().map(|oid| {
+                        oid.to_id_string()
+                    }).collect::<Vec<String>>().join(", ")
+                )
+            ].to_vec()))
+        },
+        ParsedExtension::CRLDistributionPoints(crl_dist_points) => {
+            let concatenate_name = |name: &Vec<GeneralName> | -> String {
+                name.iter().map(
+                    |n| {n.to_string()}
+                ).collect::<Vec<String>>().join(" ")
+            };
+            Some(("CRL distribution points".to_string(),
+                Vec::from_iter(crl_dist_points.points.iter().map(
+                    |point| -> (String, String){
+                        (
+                            format!(
+                                "{}, {}",
+                                match &point.distribution_point {
+                                    Some(dpn) => match dpn {
+                                        DistributionPointName::FullName(name) => {
+                                            concatenate_name(name)
+                                        },
+                                        DistributionPointName::NameRelativeToCRLIssuer(_name) => {
+                                            "Relative distinguished name".to_string()
+                                        }
+                                    },
+                                    None => "No name".to_string()
+                                },
+                                match &point.crl_issuer {
+                                    Some(name) => concatenate_name(name),
+                                    None => "No issuer".to_string()
+                                }
+                            ),
+                            match &point.reasons {
+                                Some(flags) => interpret_reason_flags(flags),
+                                None => "No reasons for revocation".to_string()
+                            }
+                        )
+                    }
+                ))
+            ))
 
-        });
+        },
+        ParsedExtension::InhibitAnyPolicy(policy_inhibit_any) => {
+            Some(("Inhibit any policy".to_string(), [
+                ("Skip certs".to_string(), format_hex_from_u32(policy_inhibit_any.skip_certs))
+            ].to_vec()))
+        },
+        ParsedExtension::AuthorityInfoAccess(authority_info_access) => {
+            Some((
+                "Authority info access".to_string(),
+                Vec::from_iter(authority_info_access.accessdescs.iter().map(
+                    |description| -> (String, String) {
+                        (
+                            description.access_location.to_string(),
+                            description.access_method.to_id_string()
+                        )
+                    }))
+            ))
+        },
+        ParsedExtension::NSCertType(ns_type) => {
+            Some(("NS cert type".to_string(), [
+                ("SSL client".to_string(), ns_type.ssl_client().to_string()),
+                ("SSL server".to_string(), ns_type.ssl_server().to_string()),
+                ("Smine".to_string(), ns_type.smime().to_string()),
+                ("Object signing".to_string(), ns_type.object_signing().to_string()),
+                ("SSL CA".to_string(), ns_type.ssl_ca().to_string()),
+                ("Smine CA".to_string(), ns_type.smime_ca().to_string()),
+                ("Object signing CA".to_string(), ns_type.object_signing_ca().to_string()),
+            ].to_vec()))
+        },
+        ParsedExtension::NsCertComment(ns_cert_comment) => {
+            Some(("NS cert comment".to_string(), [
+                ("Comment".to_string(), ns_cert_comment.to_string())
+            ].to_vec()))
+        },
+        ParsedExtension::IssuingDistributionPoint(issuing_dist_point) => {
+            let point_name: String = match &issuing_dist_point.distribution_point {
+                None => "None".to_string(),
+                Some(name) => match name {
+                    DistributionPointName::FullName(general_names) => {
+                        general_names
+                            .iter().map(|gn| gn.to_string())
+                            .collect::<Vec<String>>().join(" ")
+                    },
+                    DistributionPointName::NameRelativeToCRLIssuer(_relative_name) =>
+                        "Relative distinguished name".to_string()
+                }
+            };
+            Some(("Issuing distribution point".to_string(), [
+                ("Point".to_string(), point_name),
+                ("Only contains user certs".to_string(), issuing_dist_point.only_contains_user_certs.to_string()),
+                ("Only contains CA certs".to_string(), issuing_dist_point.only_contains_ca_certs.to_string()),
+                ("Only some reasons".to_string(), match &issuing_dist_point.only_some_reasons {
+                    Some(flags) => interpret_reason_flags(&flags),
+                    None => "None".to_string()
+                }),
+                ("Indirect CRL".to_string(), issuing_dist_point.only_contains_user_certs.to_string()),
+                ("Only contains attribute certs".to_string(), issuing_dist_point.only_contains_ca_certs.to_string()),
+            ].to_vec()))
+        },
+        ParsedExtension::CRLNumber(crl_num) => {
+            Some(("CRL number".to_string(), [
+                ("Number".to_string(), crl_num.to_string())
+            ].to_vec()))
+        },
+        ParsedExtension::ReasonCode(code) => {
+            Some(("Reason code".to_string(), [
+                ("Code".to_string(), format_hex(&[code.0]))
+            ].to_vec()))
+        },
+        ParsedExtension::InvalidityDate(invalidity_date) => {
+            Some(("Invalidity date".to_string(), [
+                ("Date".to_string(), invalidity_date.to_string())
+            ].to_vec()))
+        },
+        ParsedExtension::SCT(timestamps) => {
+            Some((
+                "Signed cert timestamp(s)".to_string(),
+                Vec::from_iter(timestamps.iter().map(
+                    |sct: &SignedCertificateTimestamp| -> (String, String) {
+                        (
+                            format!("{}, {}",
+                                if sct.version == CtVersion::V1 {
+                                    "v1(0)".to_string()
+                                } else {
+                                    format_hex(&[sct.version.0])
+                                },
+                                format_hex(sct.id.key_id)
+                            ),
+                            format!("Timestamp: {}, Signature: {}",
+                                ASN1Time::from_timestamp(sct.timestamp.cast_signed()).unwrap().to_string(),
+                                format_hex(&sct.signature.data)
+                            )
+                        )
+                    }
+                ))
+            ))
+        },
+
+        ParsedExtension::UnsupportedExtension {oid} => {
+            Some(("Unsupported extension".to_string(), [
+                ("Extension ID".to_string(), oid.to_id_string())
+            ].to_vec()))
+        },
+        ParsedExtension::ParseError {error: _error} => {
+            None
+        },
+        ParsedExtension::Unparsed => {
+            None
+        },
+        _ => None
     }
-
-    Ok(VerboseCert{
-        base_cert: parse_der_cert(der_data)?,
-        extensions: extensions
-    })
 }
 
 fn extract_key_info(cert: &X509Certificate<'_>) -> (KeyType, u32) {

--- a/src/cert/parser.rs
+++ b/src/cert/parser.rs
@@ -1,3 +1,5 @@
+use std::collections::HashMap;
+use std::io::Read;
 use anyhow::{bail, Context, Result};
 use x509_parser::prelude::*;
 use x509_parser::public_key::PublicKey;
@@ -101,53 +103,189 @@ pub fn parse_der_cert(der_data: &[u8]) -> Result<CertInfo> {
     })
 }
 
+// Verbose parsing
+pub fn verbose_parse_cert_file(path: &str) -> Result<Vec<VerboseCert>> {
+    let data = std::fs::read(path).with_context(|| format!("can't read {}", path))?;
+    verbose_parse_cert_data_with_source(&data, path)
+}
+
+/// Parse certificate(s) from raw bytes (PEM or DER).
+/// Use this when data is already in memory (e.g. read from stdin).
+pub fn verbose_parse_cert_data(data: &[u8]) -> Result<Vec<VerboseCert>> {
+    verbose_parse_cert_data_with_source(data, "stdin")
+}
+
+pub fn verbose_parse_cert_data_from(data: &[u8], source: &str) -> Result<Vec<VerboseCert>> {
+    verbose_parse_cert_data_with_source(data, source)
+}
+
+fn verbose_parse_cert_data_with_source(data: &[u8], source: &str) -> Result<Vec<VerboseCert>> {
+    if is_pem(data) {
+        verbose_parse_pem_certs(data)
+    } else if is_der(data) {
+        verbose_parse_der_cert(data).map(|c| vec![c])
+    } else {
+        bail!(
+            "Unrecognized certificate format in '{}'. Expected PEM or DER.\n\
+             Hint: PEM files start with '-----BEGIN CERTIFICATE-----'\n\
+             Hint: For PKCS12 (.p12/.pfx), use the convert or extract command",
+            source
+        )
+    }
+}
+
+pub fn verbose_parse_pem_certs(data: &[u8]) -> Result<Vec<VerboseCert>> {
+    let pem_blocks = parse_pem_blocks(data)?;
+
+    if pem_blocks.is_empty() {
+        bail!("No certificates found in PEM data");
+    }
+
+    let mut certs = Vec::new();
+    for (i, block) in pem_blocks.iter().enumerate() {
+        let cert = verbose_parse_der_cert(block)
+            .with_context(|| format!("certificate {} in bundle is invalid", i + 1))?;
+        certs.push(cert);
+    }
+
+    Ok(certs)
+}
+
 fn verbose_parse_der_cert(der_data: &[u8]) -> Result<VerboseCert> {
     let (_, cert) = X509Certificate::from_der(der_data)
         .map_err(|e| anyhow::anyhow!("bad certificate: {}", e))?;
 
-    // Key usage
-    let key_usage = cert.key_usage()?;
-    let key_usage = if key_usage.is_some() {
-        key_usage.unwrap().value.to_string()
-    } else {String::from("None")};
-    let extended_key_usage = cert.extended_key_usage()?.unwrap().value; //fixme
+    // Could go to a HashMap<String, [(String,String)]>
+    let mut extensions: HashMap<String, String> = HashMap::new();
 
-    // Policy constraints
-    let policy_constraints = cert.policy_constraints()?;
-    let (require_explicit_policy, inhibit_policy_mapping) = if policy_constraints.is_some() {
-        let p = policy_constraints.unwrap().value;
-        (
-            p.require_explicit_policy.unwrap().to_string(),
-            p.inhibit_policy_mapping.unwrap().to_string()
-        )
-    } else {
-        (String::from("None"), String::from("None"))
-    };
+    for e in cert.iter_extensions() {
+        // List of extensions: https://docs.rs/x509-parser/0.18.1/x509_parser/extensions/enum.ParsedExtension.html
+        extensions.extend(match e.parsed_extension() {
+            ParsedExtension::AuthorityKeyIdentifier(authority_key_id) => {
+                [
+                    (
+                        "Authority key identifier".to_string(),
+                         match &authority_key_id.key_identifier {
+                            None => "None".to_string(),
+                            Some(id) => format_hex(id.0)
+                        }
+                    ),
+                    (
+                        "Authority cert issuer".to_string(),
+                         match &authority_key_id.authority_cert_issuer {
+                            None => "None".to_string(),
+                            Some(issuer) =>
+                                String::from_iter(
+                                    issuer.iter().map(|gn| gn.to_string())
+                                ) //check this
+                        }
+                    ),
+                    (
+                        "Authority cert serial".to_string(),
+                         match authority_key_id.authority_cert_serial {
+                             None => "None".to_string(),
+                             Some(serial) => format_hex(serial)
+                         }
+                    )
+                ].to_vec()
+            },
+            ParsedExtension::SubjectKeyIdentifier(subject_key_id) => {
+                [].to_vec()
+            },
+            ParsedExtension::KeyUsage(key_usage) => {
+                [
+                    ("Digital signature".to_string(), key_usage.digital_signature().to_string()),
+                    ("Non repudiation".to_string(), key_usage.non_repudiation().to_string()),
+                    ("Key encipherment".to_string(), key_usage.key_encipherment().to_string()),
+                    ("Data encipherment".to_string(), key_usage.data_encipherment().to_string()),
+                    ("Key agreement".to_string(), key_usage.key_agreement().to_string()),
+                    ("Key cert sign".to_string(), key_usage.key_cert_sign().to_string()),
+                    ("CRL sign".to_string(), key_usage.key_encipherment().to_string()),
+                    ("Encipher only".to_string(), key_usage.key_encipherment().to_string()),
+                    ("Decipher only".to_string(), key_usage.key_encipherment().to_string()),
+                ].to_vec()
+            },
+            ParsedExtension::CertificatePolicies(cert_policies) => {
+                Vec::from_iter(cert_policies.iter().map(
+                    |policy_information| {
+                        (
+                            format!("Policy {}", policy_information.policy_id),
+                             match &policy_information.policy_qualifiers {
+                                 None => "None".to_string(),
+                                 Some(qualifiers) => "todo".to_string()
+                             }
+                        )
+                }))
+            },
+            ParsedExtension::PolicyMappings(policy_mappings) => {
+                [].to_vec()
+            },
+            ParsedExtension::SubjectAlternativeName(subject_alt_name) => {
+                [].to_vec()
+            },
+            ParsedExtension::IssuerAlternativeName(issuer_alt_name) => {
+                [].to_vec()
+            },
+            ParsedExtension::BasicConstraints(constraints_basic) => {
+                [].to_vec()
+            },
+            ParsedExtension::NameConstraints(constraints_name) => {
+                [].to_vec()
+            },
+            ParsedExtension::PolicyConstraints(constraints_policy) => {
+                [].to_vec()
+            },
+            ParsedExtension::ExtendedKeyUsage(extended_key_usage) => {
+                [].to_vec()
+            },
+            ParsedExtension::CRLDistributionPoints(crl_dist_points) => {
+                [].to_vec()
+            },
+            ParsedExtension::InhibitAnyPolicy(policy_inhibit_any) => {
+                [].to_vec()
+            },
+            ParsedExtension::AuthorityInfoAccess(authority_info_access) => {
+                [].to_vec()
+            },
+            ParsedExtension::NSCertType(ns_cert_type) => {
+                [].to_vec()
+            },
+            ParsedExtension::NsCertComment(ns_cert_comment) => {
+                [].to_vec()
+            },
+            ParsedExtension::IssuingDistributionPoint(issuing_dist_point) => {
+                [].to_vec()
+            },
+            ParsedExtension::CRLNumber(crl_num) => {
+                [].to_vec()
+            },
+            ParsedExtension::ReasonCode(reason_code) => {
+                [].to_vec()
+            },
+            ParsedExtension::InvalidityDate(invalidity_date) => {
+                [].to_vec()
+            },
+            ParsedExtension::SCT(sct) => {
+                [].to_vec()
+            },
 
-    let inhibit_anypolicy = cert.inhibit_anypolicy()?.unwrap().value;
+            ParsedExtension::UnsupportedExtension {oid} => {
+                [("Unsupported extension".to_string(), oid.to_string())].to_vec()
+            },
+            ParsedExtension::ParseError {error} => {
+                [].to_vec()
+            },
+            ParsedExtension::Unparsed => {
+                [].to_vec()
+            },
+            _ => Vec::new()
 
-    // CRLDistributionPoints
-
-
-    /*
-    InhibitAnyPolicy(InhibitAnyPolicy),
-    AuthorityInfoAccess(AuthorityInfoAccess<'a>),
-    SubjectInfoAccess(SubjectInfoAccess<'a>),
-    NSCertType(NSCertType),
-    NsCertComment(&'a str),
-    IssuingDistributionPoint(IssuingDistributionPoint<'a>),
-    CRLNumber(BigUint),
-    ReasonCode(ReasonCode),
-    InvalidityDate(ASN1Time),
-    SCT(Vec<SignedCertificateTimestamp<'a>>),
-     */
+        });
+    }
 
     Ok(VerboseCert{
         base_cert: parse_der_cert(der_data)?,
-        key_usage,
-        extended_key_usage,
-        require_explicit_policy,
-        inhibit_policy_mapping
+        extensions: extensions
     })
 }
 

--- a/src/cert/parser.rs
+++ b/src/cert/parser.rs
@@ -1,6 +1,6 @@
-use std::collections::HashMap;
 use anyhow::{bail, Context, Result};
 use rustls::internal::msgs::codec::Codec;
+use std::collections::HashMap;
 use x509_parser::prelude::*;
 use x509_parser::public_key::PublicKey;
 
@@ -18,7 +18,7 @@ fn format_hex(bytes: &[u8]) -> String {
 fn format_hex_from_u32(bytes: u32) -> String {
     let mut buf: Vec<u8> = Vec::new();
     bytes.encode(&mut buf);
-    format_hex(&*buf)
+    format_hex(&buf)
 }
 
 pub fn parse_cert_file(path: &str) -> Result<Vec<CertInfo>> {
@@ -121,10 +121,6 @@ pub fn verbose_parse_cert_data(data: &[u8]) -> Result<Vec<VerboseCert>> {
     verbose_parse_cert_data_with_source(data, "stdin")
 }
 
-pub fn verbose_parse_cert_data_from(data: &[u8], source: &str) -> Result<Vec<VerboseCert>> {
-    verbose_parse_cert_data_with_source(data, source)
-}
-
 fn verbose_parse_cert_data_with_source(data: &[u8], source: &str) -> Result<Vec<VerboseCert>> {
     if is_pem(data) {
         verbose_parse_pem_certs(data)
@@ -157,7 +153,7 @@ pub fn verbose_parse_pem_certs(data: &[u8]) -> Result<Vec<VerboseCert>> {
     Ok(certs)
 }
 
-fn verbose_parse_der_cert(der_data: &[u8]) -> Result<VerboseCert> {
+pub fn verbose_parse_der_cert(der_data: &[u8]) -> Result<VerboseCert> {
     let (_, cert) = X509Certificate::from_der(der_data)
         .map_err(|e| anyhow::anyhow!("bad certificate: {}", e))?;
 
@@ -165,15 +161,14 @@ fn verbose_parse_der_cert(der_data: &[u8]) -> Result<VerboseCert> {
     let mut extensions: HashMap<String, Vec<(String, String)>> = HashMap::new();
 
     for e in cert.iter_extensions() {
-        match parse_der_extension(e) {
-            Some(d) =>{extensions.insert(d.0, d.1);},
-            None => {}
+        if let Some(d) = parse_der_extension(e) {
+            extensions.insert(d.0, d.1);
         }
     }
 
     Ok(VerboseCert {
         base_cert: parse_der_cert(der_data)?,
-        extensions
+        extensions,
     })
 }
 
@@ -193,308 +188,406 @@ fn parse_der_extension(e: &X509Extension) -> Option<(String, Vec<(String, String
         )
     };
 
+    /*
+    Match each extension in the enum and then format it to be rendered:
+    Each extension is a tuple, which is then placed in the HashMap with key being its title
+    and the body being a vec of (String, String) tuples which represent fields and their values
+    within the extension
+     */
     match e.parsed_extension() {
         ParsedExtension::AuthorityKeyIdentifier(authority_key_id) => {
-            Some(("Authority key identifier".to_string(), [
-                (
-                    "Key identifier".to_string(),
-                    match &authority_key_id.key_identifier {
-                        None => "None".to_string(),
-                        Some(id) => format_hex(id.0)
-                    }
-                ),
-                (
-                    "Authority cert issuer".to_string(),
-                    match &authority_key_id.authority_cert_issuer {
-                        None => "None".to_string(),
-                        Some(issuer) =>
-                            String::from_iter(
-                                issuer.iter().map(|gn| gn.to_string())
-                            ) //check this
-                    }
-                ),
-                (
-                    "Authority cert serial".to_string(),
-                    match authority_key_id.authority_cert_serial {
-                        None => "None".to_string(),
-                        Some(serial) => format_hex(serial)
-                    }
-                )
-            ].to_vec()))
-        },
-        ParsedExtension::SubjectKeyIdentifier(key_id) => {
-            Some(("Subject key identifier".to_string(), [
-                ("Subject key id".to_string(), format_hex(key_id.0))
-            ].to_vec()))
-        },
-        ParsedExtension::KeyUsage(key_usage) => {
-            Some(("Key usage".to_string(), [
-                ("Digital signature".to_string(), key_usage.digital_signature().to_string()),
-                ("Non repudiation".to_string(), key_usage.non_repudiation().to_string()),
-                ("Key encipherment".to_string(), key_usage.key_encipherment().to_string()),
-                ("Data encipherment".to_string(), key_usage.data_encipherment().to_string()),
-                ("Key agreement".to_string(), key_usage.key_agreement().to_string()),
-                ("Key cert sign".to_string(), key_usage.key_cert_sign().to_string()),
-                ("CRL sign".to_string(), key_usage.key_encipherment().to_string()),
-                ("Encipher only".to_string(), key_usage.key_encipherment().to_string()),
-                ("Decipher only".to_string(), key_usage.key_encipherment().to_string()),
-            ].to_vec()))
-        },
-        ParsedExtension::CertificatePolicies(cert_policies) => {
-            Some(("Certificate policies".to_string(), Vec::from_iter(cert_policies.iter().map(
-                |policy_information| {
+            Some((
+                "Authority key identifier".to_string(),
+                [
                     (
-                        format!("Policy {}", policy_information.policy_id.to_id_string()),
-
-                        match &policy_information.policy_qualifiers {
-                            Some(qualifiers) =>
-                                qualifiers.iter().map(|pqi| {
-                                    format!(
-                                        "{}: {}",
-                                        pqi.policy_qualifier_id.to_id_string(),
-                                        format_hex(&pqi.qualifier)
-                                    )
-                                }).collect::<Vec<_>>().join(", "),
-                            None => "None".to_string()
-                        }
-                    )
-                }))))
-        },
-        ParsedExtension::PolicyMappings(policy_mappings) => {
-            Some(("Policy mappings".to_string(),
-             policy_mappings.mappings.iter().map(
-                 |mapping| {
-                     (
-                         mapping.issuer_domain_policy.to_id_string(),
-                         mapping.subject_domain_policy.to_id_string()
-                     )
-                 }
-             ).collect::<Vec<(String, String)>>()
+                        "Key identifier".to_string(),
+                        match &authority_key_id.key_identifier {
+                            None => "None".to_string(),
+                            Some(id) => format_hex(id.0),
+                        },
+                    ),
+                    (
+                        "Authority cert issuer".to_string(),
+                        match &authority_key_id.authority_cert_issuer {
+                            None => "None".to_string(),
+                            Some(issuer) => {
+                                String::from_iter(issuer.iter().map(|gn| gn.to_string()))
+                            }
+                        },
+                    ),
+                    (
+                        "Authority cert serial".to_string(),
+                        match authority_key_id.authority_cert_serial {
+                            None => "None".to_string(),
+                            Some(serial) => format_hex(serial),
+                        },
+                    ),
+                ]
+                .to_vec(),
             ))
-        },
-        ParsedExtension::SubjectAlternativeName(subject_alt_name) => {
-            Some(("Subject alternative name".to_string(), [
-                ("Name(s)".to_string(), format!("{:?}", subject_alt_name.general_names))
-            ].to_vec()))
-        },
-        ParsedExtension::IssuerAlternativeName(issuer_alt_name) => {
-            Some(("Issuer alternative name".to_string(), [
-                ("Name(s)".to_string(), format!("{:?}", issuer_alt_name.general_names))
-            ].to_vec()))
-        },
+        }
+        ParsedExtension::SubjectKeyIdentifier(key_id) => Some((
+            "Subject key identifier".to_string(),
+            [("Subject key id".to_string(), format_hex(key_id.0))].to_vec(),
+        )),
+        ParsedExtension::KeyUsage(key_usage) => Some((
+            "Key usage".to_string(),
+            [
+                (
+                    "Digital signature".to_string(),
+                    key_usage.digital_signature().to_string(),
+                ),
+                (
+                    "Non repudiation".to_string(),
+                    key_usage.non_repudiation().to_string(),
+                ),
+                (
+                    "Key encipherment".to_string(),
+                    key_usage.key_encipherment().to_string(),
+                ),
+                (
+                    "Data encipherment".to_string(),
+                    key_usage.data_encipherment().to_string(),
+                ),
+                (
+                    "Key agreement".to_string(),
+                    key_usage.key_agreement().to_string(),
+                ),
+                (
+                    "Key cert sign".to_string(),
+                    key_usage.key_cert_sign().to_string(),
+                ),
+                (
+                    "CRL sign".to_string(),
+                    key_usage.key_encipherment().to_string(),
+                ),
+                (
+                    "Encipher only".to_string(),
+                    key_usage.key_encipherment().to_string(),
+                ),
+                (
+                    "Decipher only".to_string(),
+                    key_usage.key_encipherment().to_string(),
+                ),
+            ]
+            .to_vec(),
+        )),
+        ParsedExtension::CertificatePolicies(cert_policies) => Some((
+            "Certificate policies".to_string(),
+            Vec::from_iter(cert_policies.iter().map(|policy_information| {
+                (
+                    format!("Policy {}", policy_information.policy_id.to_id_string()),
+                    match &policy_information.policy_qualifiers {
+                        Some(qualifiers) => qualifiers
+                            .iter()
+                            .map(|pqi| {
+                                format!(
+                                    "{}: {}",
+                                    pqi.policy_qualifier_id.to_id_string(),
+                                    format_hex(pqi.qualifier)
+                                )
+                            })
+                            .collect::<Vec<_>>()
+                            .join(", "),
+                        None => "None".to_string(),
+                    },
+                )
+            })),
+        )),
+        ParsedExtension::PolicyMappings(policy_mappings) => Some((
+            "Policy mappings".to_string(),
+            policy_mappings
+                .mappings
+                .iter()
+                .map(|mapping| {
+                    (
+                        mapping.issuer_domain_policy.to_id_string(),
+                        mapping.subject_domain_policy.to_id_string(),
+                    )
+                })
+                .collect::<Vec<(String, String)>>(),
+        )),
+        ParsedExtension::SubjectAlternativeName(subject_alt_name) => Some((
+            "Subject alternative name".to_string(),
+            [(
+                "Name(s)".to_string(),
+                format!("{:?}", subject_alt_name.general_names),
+            )]
+            .to_vec(),
+        )),
+        ParsedExtension::IssuerAlternativeName(issuer_alt_name) => Some((
+            "Issuer alternative name".to_string(),
+            [(
+                "Name(s)".to_string(),
+                format!("{:?}", issuer_alt_name.general_names),
+            )]
+            .to_vec(),
+        )),
         ParsedExtension::BasicConstraints(_) => {
             // Handled in CertInfo
             None
-        },
+        }
         ParsedExtension::NameConstraints(constraints_name) => {
             let format_subtrees =
-                |subtrees_options: &Option<Vec<GeneralSubtree>>| {
-                    match subtrees_options {
-                        Some(subtrees) => subtrees.iter().map(
-                            |tree| {
-                                tree.base.to_string()
-                            }
-                        ).collect::<Vec<String>>().join(", "),
-                        None => "None".to_string()
-                    }
+                |subtrees_options: &Option<Vec<GeneralSubtree>>| match subtrees_options {
+                    Some(subtrees) => subtrees
+                        .iter()
+                        .map(|tree| tree.base.to_string())
+                        .collect::<Vec<String>>()
+                        .join(", "),
+                    None => "None".to_string(),
                 };
 
-            Some(("Name constraints".to_string(), [
-                (
-                    "Permitted subtrees".to_string(),
-                    format_subtrees(&constraints_name.permitted_subtrees)
-                ),
-                (
-                    "Permitted subtrees".to_string(),
-                    format_subtrees(&constraints_name.excluded_subtrees)
-                )
-            ].to_vec()))
-        },
+            Some((
+                "Name constraints".to_string(),
+                [
+                    (
+                        "Permitted subtrees".to_string(),
+                        format_subtrees(&constraints_name.permitted_subtrees),
+                    ),
+                    (
+                        "Permitted subtrees".to_string(),
+                        format_subtrees(&constraints_name.excluded_subtrees),
+                    ),
+                ]
+                .to_vec(),
+            ))
+        }
         ParsedExtension::PolicyConstraints(constraints_policy) => {
-            let format_constraint = |constraint: &Option<u32>| {
-                match constraint {
-                    Some(u) => {
-                        format_hex_from_u32(*u)
-                    },
-                    None => "None".to_string()
-                }
+            let format_constraint = |constraint: &Option<u32>| match constraint {
+                Some(u) => format_hex_from_u32(*u),
+                None => "None".to_string(),
             };
 
-            Some(("Policy constraints".to_string(), [
+            Some((
+                "Policy constraints".to_string(),
+                [
+                    (
+                        "Require explicit policy".to_string(),
+                        format_constraint(&constraints_policy.inhibit_policy_mapping),
+                    ),
+                    (
+                        "Inhibit policy mapping".to_string(),
+                        format_constraint(&constraints_policy.require_explicit_policy),
+                    ),
+                ]
+                .to_vec(),
+            ))
+        }
+        ParsedExtension::ExtendedKeyUsage(extended_key_usage) => Some((
+            "Extended key usage".to_string(),
+            [
+                ("Any".to_string(), extended_key_usage.any.to_string()),
                 (
-                    "Require explicit policy".to_string(),
-                    format_constraint(&constraints_policy.inhibit_policy_mapping)
+                    "Server authentication".to_string(),
+                    extended_key_usage.server_auth.to_string(),
                 ),
                 (
-                    "Inhibit policy mapping".to_string(),
-                    format_constraint(&constraints_policy.require_explicit_policy)
-                )
-            ].to_vec()))
-        },
-        ParsedExtension::ExtendedKeyUsage(extended_key_usage) => {
-            Some(("Extended key usage".to_string(), [
-                ("Any".to_string(), extended_key_usage.any.to_string()),
-                ("Server authentication".to_string(), extended_key_usage.server_auth.to_string()),
-                ("Client authentication".to_string(), extended_key_usage.client_auth.to_string()),
-                ("Code signing".to_string(), extended_key_usage.code_signing.to_string()),
-                ("Email protection".to_string(), extended_key_usage.email_protection.to_string()),
-                ("Time stamping".to_string(), extended_key_usage.time_stamping.to_string()),
-                ("OCSP signing".to_string(), extended_key_usage.ocsp_signing.to_string()),
+                    "Client authentication".to_string(),
+                    extended_key_usage.client_auth.to_string(),
+                ),
+                (
+                    "Code signing".to_string(),
+                    extended_key_usage.code_signing.to_string(),
+                ),
+                (
+                    "Email protection".to_string(),
+                    extended_key_usage.email_protection.to_string(),
+                ),
+                (
+                    "Time stamping".to_string(),
+                    extended_key_usage.time_stamping.to_string(),
+                ),
+                (
+                    "OCSP signing".to_string(),
+                    extended_key_usage.ocsp_signing.to_string(),
+                ),
                 (
                     "Other".to_string(),
-                    extended_key_usage.other.iter().map(|oid| {
-                        oid.to_id_string()
-                    }).collect::<Vec<String>>().join(", ")
-                )
-            ].to_vec()))
-        },
+                    extended_key_usage
+                        .other
+                        .iter()
+                        .map(|oid| oid.to_id_string())
+                        .collect::<Vec<String>>()
+                        .join(", "),
+                ),
+            ]
+            .to_vec(),
+        )),
         ParsedExtension::CRLDistributionPoints(crl_dist_points) => {
-            let concatenate_name = |name: &Vec<GeneralName> | -> String {
-                name.iter().map(
-                    |n| {n.to_string()}
-                ).collect::<Vec<String>>().join(" ")
+            let concatenate_name = |name: &Vec<GeneralName>| -> String {
+                name.iter()
+                    .map(|n| n.to_string())
+                    .collect::<Vec<String>>()
+                    .join(" ")
             };
-            Some(("CRL distribution points".to_string(),
-                Vec::from_iter(crl_dist_points.points.iter().map(
-                    |point| -> (String, String){
-                        (
-                            format!(
-                                "{}, {}",
-                                match &point.distribution_point {
-                                    Some(dpn) => match dpn {
-                                        DistributionPointName::FullName(name) => {
-                                            concatenate_name(name)
-                                        },
-                                        DistributionPointName::NameRelativeToCRLIssuer(_name) => {
-                                            "Relative distinguished name".to_string()
-                                        }
-                                    },
-                                    None => "No name".to_string()
-                                },
-                                match &point.crl_issuer {
-                                    Some(name) => concatenate_name(name),
-                                    None => "No issuer".to_string()
-                                }
-                            ),
-                            match &point.reasons {
-                                Some(flags) => interpret_reason_flags(flags),
-                                None => "No reasons for revocation".to_string()
-                            }
-                        )
-                    }
-                ))
-            ))
-
-        },
-        ParsedExtension::InhibitAnyPolicy(policy_inhibit_any) => {
-            Some(("Inhibit any policy".to_string(), [
-                ("Skip certs".to_string(), format_hex_from_u32(policy_inhibit_any.skip_certs))
-            ].to_vec()))
-        },
-        ParsedExtension::AuthorityInfoAccess(authority_info_access) => {
             Some((
-                "Authority info access".to_string(),
-                Vec::from_iter(authority_info_access.accessdescs.iter().map(
-                    |description| -> (String, String) {
-                        (
-                            description.access_location.to_string(),
-                            description.access_method.to_id_string()
-                        )
-                    }))
+                "CRL distribution points".to_string(),
+                Vec::from_iter(
+                    crl_dist_points
+                        .points
+                        .iter()
+                        .map(|point| -> (String, String) {
+                            (
+                                format!(
+                                    "{}, {}",
+                                    match &point.distribution_point {
+                                        Some(dpn) => match dpn {
+                                            DistributionPointName::FullName(name) => {
+                                                concatenate_name(name)
+                                            }
+                                            DistributionPointName::NameRelativeToCRLIssuer(
+                                                _name,
+                                            ) => {
+                                                "Relative distinguished name".to_string()
+                                            }
+                                        },
+                                        None => "No name".to_string(),
+                                    },
+                                    match &point.crl_issuer {
+                                        Some(name) => concatenate_name(name),
+                                        None => "No issuer".to_string(),
+                                    }
+                                ),
+                                match &point.reasons {
+                                    Some(flags) => interpret_reason_flags(flags),
+                                    None => "No reasons for revocation".to_string(),
+                                },
+                            )
+                        }),
+                ),
             ))
-        },
-        ParsedExtension::NSCertType(ns_type) => {
-            Some(("NS cert type".to_string(), [
+        }
+        ParsedExtension::InhibitAnyPolicy(policy_inhibit_any) => Some((
+            "Inhibit any policy".to_string(),
+            [(
+                "Skip certs".to_string(),
+                format_hex_from_u32(policy_inhibit_any.skip_certs),
+            )]
+            .to_vec(),
+        )),
+        ParsedExtension::AuthorityInfoAccess(authority_info_access) => Some((
+            "Authority info access".to_string(),
+            Vec::from_iter(authority_info_access.accessdescs.iter().map(
+                |description| -> (String, String) {
+                    (
+                        description.access_location.to_string(),
+                        description.access_method.to_id_string(),
+                    )
+                },
+            )),
+        )),
+        ParsedExtension::NSCertType(ns_type) => Some((
+            "NS cert type".to_string(),
+            [
                 ("SSL client".to_string(), ns_type.ssl_client().to_string()),
                 ("SSL server".to_string(), ns_type.ssl_server().to_string()),
                 ("Smine".to_string(), ns_type.smime().to_string()),
-                ("Object signing".to_string(), ns_type.object_signing().to_string()),
+                (
+                    "Object signing".to_string(),
+                    ns_type.object_signing().to_string(),
+                ),
                 ("SSL CA".to_string(), ns_type.ssl_ca().to_string()),
                 ("Smine CA".to_string(), ns_type.smime_ca().to_string()),
-                ("Object signing CA".to_string(), ns_type.object_signing_ca().to_string()),
-            ].to_vec()))
-        },
-        ParsedExtension::NsCertComment(ns_cert_comment) => {
-            Some(("NS cert comment".to_string(), [
-                ("Comment".to_string(), ns_cert_comment.to_string())
-            ].to_vec()))
-        },
+                (
+                    "Object signing CA".to_string(),
+                    ns_type.object_signing_ca().to_string(),
+                ),
+            ]
+            .to_vec(),
+        )),
+        ParsedExtension::NsCertComment(ns_cert_comment) => Some((
+            "NS cert comment".to_string(),
+            [("Comment".to_string(), ns_cert_comment.to_string())].to_vec(),
+        )),
         ParsedExtension::IssuingDistributionPoint(issuing_dist_point) => {
             let point_name: String = match &issuing_dist_point.distribution_point {
                 None => "None".to_string(),
                 Some(name) => match name {
-                    DistributionPointName::FullName(general_names) => {
-                        general_names
-                            .iter().map(|gn| gn.to_string())
-                            .collect::<Vec<String>>().join(" ")
-                    },
-                    DistributionPointName::NameRelativeToCRLIssuer(_relative_name) =>
+                    DistributionPointName::FullName(general_names) => general_names
+                        .iter()
+                        .map(|gn| gn.to_string())
+                        .collect::<Vec<String>>()
+                        .join(" "),
+                    DistributionPointName::NameRelativeToCRLIssuer(_relative_name) => {
                         "Relative distinguished name".to_string()
-                }
-            };
-            Some(("Issuing distribution point".to_string(), [
-                ("Point".to_string(), point_name),
-                ("Only contains user certs".to_string(), issuing_dist_point.only_contains_user_certs.to_string()),
-                ("Only contains CA certs".to_string(), issuing_dist_point.only_contains_ca_certs.to_string()),
-                ("Only some reasons".to_string(), match &issuing_dist_point.only_some_reasons {
-                    Some(flags) => interpret_reason_flags(&flags),
-                    None => "None".to_string()
-                }),
-                ("Indirect CRL".to_string(), issuing_dist_point.only_contains_user_certs.to_string()),
-                ("Only contains attribute certs".to_string(), issuing_dist_point.only_contains_ca_certs.to_string()),
-            ].to_vec()))
-        },
-        ParsedExtension::CRLNumber(crl_num) => {
-            Some(("CRL number".to_string(), [
-                ("Number".to_string(), crl_num.to_string())
-            ].to_vec()))
-        },
-        ParsedExtension::ReasonCode(code) => {
-            Some(("Reason code".to_string(), [
-                ("Code".to_string(), format_hex(&[code.0]))
-            ].to_vec()))
-        },
-        ParsedExtension::InvalidityDate(invalidity_date) => {
-            Some(("Invalidity date".to_string(), [
-                ("Date".to_string(), invalidity_date.to_string())
-            ].to_vec()))
-        },
-        ParsedExtension::SCT(timestamps) => {
-            Some((
-                "Signed cert timestamp(s)".to_string(),
-                Vec::from_iter(timestamps.iter().map(
-                    |sct: &SignedCertificateTimestamp| -> (String, String) {
-                        (
-                            format!("{}, {}",
-                                if sct.version == CtVersion::V1 {
-                                    "v1(0)".to_string()
-                                } else {
-                                    format_hex(&[sct.version.0])
-                                },
-                                format_hex(sct.id.key_id)
-                            ),
-                            format!("Timestamp: {}, Signature: {}",
-                                ASN1Time::from_timestamp(sct.timestamp.cast_signed()).unwrap().to_string(),
-                                format_hex(&sct.signature.data)
-                            )
-                        )
                     }
-                ))
+                },
+            };
+            Some((
+                "Issuing distribution point".to_string(),
+                [
+                    ("Point".to_string(), point_name),
+                    (
+                        "Only contains user certs".to_string(),
+                        issuing_dist_point.only_contains_user_certs.to_string(),
+                    ),
+                    (
+                        "Only contains CA certs".to_string(),
+                        issuing_dist_point.only_contains_ca_certs.to_string(),
+                    ),
+                    (
+                        "Only some reasons".to_string(),
+                        match &issuing_dist_point.only_some_reasons {
+                            Some(flags) => interpret_reason_flags(flags),
+                            None => "None".to_string(),
+                        },
+                    ),
+                    (
+                        "Indirect CRL".to_string(),
+                        issuing_dist_point.only_contains_user_certs.to_string(),
+                    ),
+                    (
+                        "Only contains attribute certs".to_string(),
+                        issuing_dist_point.only_contains_ca_certs.to_string(),
+                    ),
+                ]
+                .to_vec(),
             ))
-        },
+        }
+        ParsedExtension::CRLNumber(crl_num) => Some((
+            "CRL number".to_string(),
+            [("Number".to_string(), crl_num.to_string())].to_vec(),
+        )),
+        ParsedExtension::ReasonCode(code) => Some((
+            "Reason code".to_string(),
+            [("Code".to_string(), format_hex(&[code.0]))].to_vec(),
+        )),
+        ParsedExtension::InvalidityDate(invalidity_date) => Some((
+            "Invalidity date".to_string(),
+            [("Date".to_string(), invalidity_date.to_string())].to_vec(),
+        )),
+        ParsedExtension::SCT(timestamps) => Some((
+            "Signed cert timestamp(s)".to_string(),
+            Vec::from_iter(timestamps.iter().map(
+                |sct: &SignedCertificateTimestamp| -> (String, String) {
+                    (
+                        format!(
+                            "{}, {}",
+                            if sct.version == CtVersion::V1 {
+                                "v1(0)".to_string()
+                            } else {
+                                format_hex(&[sct.version.0])
+                            },
+                            format_hex(sct.id.key_id)
+                        ),
+                        format!(
+                            "Timestamp: {}, Signature: {}",
+                            ASN1Time::from_timestamp(sct.timestamp.cast_signed()).unwrap(),
+                            format_hex(sct.signature.data)
+                        ),
+                    )
+                },
+            )),
+        )),
 
-        ParsedExtension::UnsupportedExtension {oid} => {
-            Some(("Unsupported extension".to_string(), [
-                ("Extension ID".to_string(), oid.to_id_string())
-            ].to_vec()))
-        },
-        ParsedExtension::ParseError {error: _error} => {
-            None
-        },
-        ParsedExtension::Unparsed => {
-            None
-        },
-        _ => None
+        ParsedExtension::UnsupportedExtension { oid } => Some((
+            "Unsupported extension".to_string(),
+            [("Extension ID".to_string(), oid.to_id_string())].to_vec(),
+        )),
+        ParsedExtension::ParseError { error: _error } => None,
+        ParsedExtension::Unparsed => None,
+        _ => None,
     }
 }
 

--- a/src/cert/parser.rs
+++ b/src/cert/parser.rs
@@ -64,6 +64,9 @@ pub fn parse_der_cert(der_data: &[u8]) -> Result<CertInfo> {
     let (_, cert) = X509Certificate::from_der(der_data)
         .map_err(|e| anyhow::anyhow!("bad certificate: {}", e))?;
 
+    // TODO Test prints
+
+
     let subject = cert.subject().to_string();
     let issuer = cert.issuer().to_string();
     let serial_hex = format_hex(cert.raw_serial());

--- a/src/commands/decode.rs
+++ b/src/commands/decode.rs
@@ -4,7 +4,7 @@ use std::io::Read;
 use crate::output::{box_chars, colors};
 
 // TODO implement verbose throughout
-pub fn run(input: &str, json: bool, verbose: bool, no_color: bool) -> Result<i32> {
+pub fn run(input: &str, json: bool, no_color: bool) -> Result<i32> {
     let use_color = !no_color && !json && colors::should_color();
 
     // Check if input is stdin, a file path, or inline string
@@ -24,7 +24,7 @@ pub fn run(input: &str, json: bool, verbose: bool, no_color: bool) -> Result<i32
 
     // Try to detect the type
     if text.starts_with("-----BEGIN CERTIFICATE") {
-        return decode_as_cert(&data, &source, json, verbose, no_color, use_color, "PEM Certificate");
+        return decode_as_cert(&data, &source, json, no_color, use_color, "PEM Certificate");
     }
 
     if text.starts_with("-----BEGIN CERTIFICATE REQUEST")
@@ -59,7 +59,7 @@ pub fn run(input: &str, json: bool, verbose: bool, no_color: bool) -> Result<i32
 
     // DER certificate
     if !data.is_empty() && data[0] == 0x30 && source != "inline" {
-        return decode_as_cert(&data, &source, json, verbose, no_color, use_color, "DER Certificate");
+        return decode_as_cert(&data, &source, json, no_color, use_color, "DER Certificate");
     }
 
     if json {
@@ -92,7 +92,6 @@ fn decode_as_cert(
     data: &[u8],
     source: &str,
     json: bool,
-    verbose: bool, // FIXME: check this
     no_color: bool,
     use_color: bool,
     label: &str,
@@ -103,7 +102,7 @@ fn decode_as_cert(
         println!("\n  Detected: {}\n", label);
     }
     let certs = crate::cert::parser::parse_cert_data_from(data, source)?;
-    crate::commands::inspect::run_certs(&certs, json, verbose, no_color)
+    crate::commands::inspect::run_certs(&certs, json, no_color)
 }
 
 fn decode_as_csr(text: &str, json: bool, use_color: bool) -> Result<i32> {

--- a/src/commands/decode.rs
+++ b/src/commands/decode.rs
@@ -3,7 +3,6 @@ use std::io::Read;
 
 use crate::output::{box_chars, colors};
 
-// TODO implement verbose throughout
 pub fn run(input: &str, json: bool, no_color: bool) -> Result<i32> {
     let use_color = !no_color && !json && colors::should_color();
 

--- a/src/commands/decode.rs
+++ b/src/commands/decode.rs
@@ -3,7 +3,8 @@ use std::io::Read;
 
 use crate::output::{box_chars, colors};
 
-pub fn run(input: &str, json: bool, no_color: bool) -> Result<i32> {
+// TODO implement verbose throughout
+pub fn run(input: &str, json: bool, verbose: bool, no_color: bool) -> Result<i32> {
     let use_color = !no_color && !json && colors::should_color();
 
     // Check if input is stdin, a file path, or inline string
@@ -23,7 +24,7 @@ pub fn run(input: &str, json: bool, no_color: bool) -> Result<i32> {
 
     // Try to detect the type
     if text.starts_with("-----BEGIN CERTIFICATE") {
-        return decode_as_cert(&data, &source, json, no_color, use_color, "PEM Certificate");
+        return decode_as_cert(&data, &source, json, verbose, no_color, use_color, "PEM Certificate");
     }
 
     if text.starts_with("-----BEGIN CERTIFICATE REQUEST")
@@ -58,7 +59,7 @@ pub fn run(input: &str, json: bool, no_color: bool) -> Result<i32> {
 
     // DER certificate
     if !data.is_empty() && data[0] == 0x30 && source != "inline" {
-        return decode_as_cert(&data, &source, json, no_color, use_color, "DER Certificate");
+        return decode_as_cert(&data, &source, json, verbose, no_color, use_color, "DER Certificate");
     }
 
     if json {
@@ -91,6 +92,7 @@ fn decode_as_cert(
     data: &[u8],
     source: &str,
     json: bool,
+    verbose: bool, // FIXME: check this
     no_color: bool,
     use_color: bool,
     label: &str,
@@ -101,7 +103,7 @@ fn decode_as_cert(
         println!("\n  Detected: {}\n", label);
     }
     let certs = crate::cert::parser::parse_cert_data_from(data, source)?;
-    crate::commands::inspect::run_certs(&certs, json, no_color)
+    crate::commands::inspect::run_certs(&certs, json, verbose, no_color)
 }
 
 fn decode_as_csr(text: &str, json: bool, use_color: bool) -> Result<i32> {

--- a/src/commands/inspect.rs
+++ b/src/commands/inspect.rs
@@ -7,7 +7,7 @@ use crate::output::json::JsonCert;
 use crate::output::json::JsonCertOutput;
 use crate::output::terminal;
 
-pub fn run(path: &str, json: bool, no_color: bool) -> Result<i32> {
+pub fn run(path: &str, json: bool, verbose: bool, no_color: bool) -> Result<i32> {
     let certs = if path == "-" {
         let mut buf = Vec::new();
         std::io::stdin().read_to_end(&mut buf)?;
@@ -15,11 +15,11 @@ pub fn run(path: &str, json: bool, no_color: bool) -> Result<i32> {
     } else {
         parse_cert_file(path)?
     };
-    run_certs(&certs, json, no_color)
+    run_certs(&certs, json, verbose, no_color)
 }
 
 /// Render already-parsed certs (used by `decode` to avoid re-reading the source).
-pub fn run_certs(certs: &[crate::cert::CertInfo], json: bool, no_color: bool) -> Result<i32> {
+pub fn run_certs(certs: &[crate::cert::CertInfo], json: bool, verbose: bool, no_color: bool) -> Result<i32> {
     let use_color = !no_color && !json && colors::should_color();
 
     if json {
@@ -29,7 +29,6 @@ pub fn run_certs(certs: &[crate::cert::CertInfo], json: bool, no_color: bool) ->
         println!("{}", serde_json::to_string_pretty(&output)?);
         return Ok(exit_code_for_certs(certs));
     }
-
     let total = certs.len();
     for (i, cert) in certs.iter().enumerate() {
         println!("{}", terminal::render_cert(cert, i, total, use_color));

--- a/src/commands/inspect.rs
+++ b/src/commands/inspect.rs
@@ -62,16 +62,17 @@ fn exit_code_for_certs(certs: &[crate::cert::CertInfo]) -> i32 {
 }
 
 pub fn verbose_run_certs(certs: &[crate::cert::VerboseCert], json: bool, no_color: bool) -> Result<i32> {
+    let use_color = !no_color && !json && colors::should_color();
+
     if json {
         bail!("Verbose json output not yet supported")
     }
 
-    for c in certs.iter() {
-        for e in c.extensions.iter() {
-            println!("--{}--", e.0);
-            for s in e.1 {
-                println!("{}: {}", s.0, s.1);
-            }
+    let total = certs.len();
+    for (i, cert) in certs.iter().enumerate() {
+        println!("{}", terminal::render_verbose_cert(cert, i, total, use_color));
+        if i < total - 1 {
+            println!("{}", terminal::render_chain_arrow(use_color));
         }
     }
 

--- a/src/commands/inspect.rs
+++ b/src/commands/inspect.rs
@@ -68,13 +68,17 @@ pub fn verbose_run_certs(certs: &[crate::cert::VerboseCert], json: bool, no_colo
 
     for c in certs.iter() {
         for e in c.extensions.iter() {
-            println!("{}: {}", e.0, e.1);
+            println!("--{}--", e.0);
+            for s in e.1 {
+                println!("{}: {}", s.0, s.1);
+            }
         }
     }
 
     Ok(exit_code_for_verbose_certs(certs))
 }
 
+// todo Use traits for this instead
 fn exit_code_for_verbose_certs(certs: &[crate::cert::VerboseCert]) -> i32 {
     if certs.iter().any(|c| c.is_expired()) {
         1 // expired

--- a/src/commands/inspect.rs
+++ b/src/commands/inspect.rs
@@ -1,25 +1,38 @@
-use anyhow::Result;
+use anyhow::{bail, Result};
 use std::io::Read;
-
-use crate::cert::parser::{parse_cert_data, parse_cert_file};
+use crate::cert::parser::{
+    parse_cert_data, parse_cert_file,
+    verbose_parse_cert_data, verbose_parse_cert_file
+};
 use crate::output::colors;
 use crate::output::json::JsonCert;
 use crate::output::json::JsonCertOutput;
 use crate::output::terminal;
 
 pub fn run(path: &str, json: bool, verbose: bool, no_color: bool) -> Result<i32> {
-    let certs = if path == "-" {
-        let mut buf = Vec::new();
-        std::io::stdin().read_to_end(&mut buf)?;
-        parse_cert_data(&buf)?
+    if !verbose {
+        let certs = if path == "-" {
+            let mut buf = Vec::new();
+            std::io::stdin().read_to_end(&mut buf)?;
+            parse_cert_data(&buf)?
+        } else {
+            parse_cert_file(path)?
+        };
+        run_certs(&certs, json, no_color)
     } else {
-        parse_cert_file(path)?
-    };
-    run_certs(&certs, json, verbose, no_color)
+        let certs = if path == "-" {
+            let mut buf = Vec::new();
+            std::io::stdin().read_to_end(&mut buf)?;
+            verbose_parse_cert_data(&buf)?
+        } else {
+            verbose_parse_cert_file(path)?
+        };
+        verbose_run_certs(&certs, json, no_color)
+    }
 }
 
 /// Render already-parsed certs (used by `decode` to avoid re-reading the source).
-pub fn run_certs(certs: &[crate::cert::CertInfo], json: bool, verbose: bool, no_color: bool) -> Result<i32> {
+pub fn run_certs(certs: &[crate::cert::CertInfo], json: bool, no_color: bool) -> Result<i32> {
     let use_color = !no_color && !json && colors::should_color();
 
     if json {
@@ -41,6 +54,28 @@ pub fn run_certs(certs: &[crate::cert::CertInfo], json: bool, verbose: bool, no_
 }
 
 fn exit_code_for_certs(certs: &[crate::cert::CertInfo]) -> i32 {
+    if certs.iter().any(|c| c.is_expired()) {
+        1 // expired
+    } else {
+        0 // valid
+    }
+}
+
+pub fn verbose_run_certs(certs: &[crate::cert::VerboseCert], json: bool, no_color: bool) -> Result<i32> {
+    if json {
+        bail!("Verbose json output not yet supported")
+    }
+
+    for c in certs.iter() {
+        for e in c.extensions.iter() {
+            println!("{}: {}", e.0, e.1);
+        }
+    }
+
+    Ok(exit_code_for_verbose_certs(certs))
+}
+
+fn exit_code_for_verbose_certs(certs: &[crate::cert::VerboseCert]) -> i32 {
     if certs.iter().any(|c| c.is_expired()) {
         1 // expired
     } else {

--- a/src/commands/inspect.rs
+++ b/src/commands/inspect.rs
@@ -1,13 +1,12 @@
-use anyhow::{bail, Result};
-use std::io::Read;
 use crate::cert::parser::{
-    parse_cert_data, parse_cert_file,
-    verbose_parse_cert_data, verbose_parse_cert_file
+    parse_cert_data, parse_cert_file, verbose_parse_cert_data, verbose_parse_cert_file,
 };
 use crate::output::colors;
 use crate::output::json::JsonCert;
 use crate::output::json::JsonCertOutput;
 use crate::output::terminal;
+use anyhow::{bail, Result};
+use std::io::Read;
 
 pub fn run(path: &str, json: bool, verbose: bool, no_color: bool) -> Result<i32> {
     if !verbose {
@@ -61,7 +60,11 @@ fn exit_code_for_certs(certs: &[crate::cert::CertInfo]) -> i32 {
     }
 }
 
-pub fn verbose_run_certs(certs: &[crate::cert::VerboseCert], json: bool, no_color: bool) -> Result<i32> {
+pub fn verbose_run_certs(
+    certs: &[crate::cert::VerboseCert],
+    json: bool,
+    no_color: bool,
+) -> Result<i32> {
     let use_color = !no_color && !json && colors::should_color();
 
     if json {
@@ -70,7 +73,10 @@ pub fn verbose_run_certs(certs: &[crate::cert::VerboseCert], json: bool, no_colo
 
     let total = certs.len();
     for (i, cert) in certs.iter().enumerate() {
-        println!("{}", terminal::render_verbose_cert(cert, i, total, use_color));
+        println!(
+            "{}",
+            terminal::render_verbose_cert(cert, i, total, use_color)
+        );
         if i < total - 1 {
             println!("{}", terminal::render_chain_arrow(use_color));
         }
@@ -79,7 +85,6 @@ pub fn verbose_run_certs(certs: &[crate::cert::VerboseCert], json: bool, no_colo
     Ok(exit_code_for_verbose_certs(certs))
 }
 
-// todo Use traits for this instead
 fn exit_code_for_verbose_certs(certs: &[crate::cert::VerboseCert]) -> i32 {
     if certs.iter().any(|c| c.is_expired()) {
         1 // expired

--- a/src/main.rs
+++ b/src/main.rs
@@ -239,7 +239,9 @@ fn main() {
 
 fn run(cli: Cli) -> anyhow::Result<i32> {
     match cli.command {
-        Commands::Inspect { file } => commands::inspect::run(&file, cli.json, cli.verbose, cli.no_color),
+        Commands::Inspect { file } => {
+            commands::inspect::run(&file, cli.json, cli.verbose, cli.no_color)
+        }
         Commands::Connect {
             host,
             sni,

--- a/src/main.rs
+++ b/src/main.rs
@@ -298,7 +298,7 @@ fn run(cli: Cli) -> anyhow::Result<i32> {
             key_type,
             out,
         } => commands::csr::run(&cn, &san, &key_type, &out, cli.json, cli.no_color),
-        Commands::Decode { input } => commands::decode::run(&input, cli.json, cli.verbose, cli.no_color),
+        Commands::Decode { input } => commands::decode::run(&input, cli.json, cli.no_color),
         Commands::Grade { host } => {
             let (host, port) = parse_host_port(&host);
             commands::grade::run(&host, port, cli.json, cli.no_color)

--- a/src/main.rs
+++ b/src/main.rs
@@ -27,6 +27,10 @@ struct Cli {
     #[arg(long, global = true)]
     json: bool,
 
+    /// Verbose output
+    #[arg(long, global = true)]
+    verbose: bool,
+
     /// Disable colored output
     #[arg(long, global = true)]
     no_color: bool,
@@ -235,7 +239,7 @@ fn main() {
 
 fn run(cli: Cli) -> anyhow::Result<i32> {
     match cli.command {
-        Commands::Inspect { file } => commands::inspect::run(&file, cli.json, cli.no_color),
+        Commands::Inspect { file } => commands::inspect::run(&file, cli.json, cli.verbose, cli.no_color),
         Commands::Connect {
             host,
             sni,
@@ -294,7 +298,7 @@ fn run(cli: Cli) -> anyhow::Result<i32> {
             key_type,
             out,
         } => commands::csr::run(&cn, &san, &key_type, &out, cli.json, cli.no_color),
-        Commands::Decode { input } => commands::decode::run(&input, cli.json, cli.no_color),
+        Commands::Decode { input } => commands::decode::run(&input, cli.json, cli.verbose, cli.no_color),
         Commands::Grade { host } => {
             let (host, port) = parse_host_port(&host);
             commands::grade::run(&host, port, cli.json, cli.no_color)

--- a/src/output/terminal.rs
+++ b/src/output/terminal.rs
@@ -13,7 +13,13 @@ pub fn render_cert(cert: &CertInfo, index: usize, total: usize, use_color: bool)
     lines.join("\n")
 }
 
-pub fn render_verbose_cert(cert: &VerboseCert, index: usize, total: usize, use_color: bool) -> String {
+/// Render a certificate verbosely with its extensions in a beautiful box
+pub fn render_verbose_cert(
+    cert: &VerboseCert,
+    index: usize,
+    total: usize,
+    use_color: bool,
+) -> String {
     let mut lines = Vec::new();
 
     render_cert_body(&cert.base_cert, &mut lines, index, total, use_color);
@@ -21,7 +27,13 @@ pub fn render_verbose_cert(cert: &VerboseCert, index: usize, total: usize, use_c
     for extension in &cert.extensions {
         // Header
         lines.push("".to_string());
-        add_row(&mut lines, extension.0.as_str(), "", colors::CYAN, use_color);
+        add_row(
+            &mut lines,
+            extension.0.as_str(),
+            "",
+            colors::CYAN,
+            use_color,
+        );
 
         // Content
         for content in extension.1 {
@@ -30,7 +42,7 @@ pub fn render_verbose_cert(cert: &VerboseCert, index: usize, total: usize, use_c
                 format!("  {}:", content.0).as_str(),
                 content.1.as_str(),
                 colors::DIM,
-                use_color
+                use_color,
             );
         }
     }
@@ -39,7 +51,14 @@ pub fn render_verbose_cert(cert: &VerboseCert, index: usize, total: usize, use_c
     lines.join("\n")
 }
 
-pub fn render_cert_body(cert: &CertInfo, lines: &mut Vec<String>, index: usize, total: usize, use_color: bool) -> () {
+// Render the header and main body of a certificate's box
+fn render_cert_body(
+    cert: &CertInfo,
+    lines: &mut Vec<String>,
+    index: usize,
+    total: usize,
+    use_color: bool,
+) {
     // Header
     let ca_label = if cert.is_ca { " (CA)" } else { "" };
     let header = format!(" Certificate {} of {}{} ", index + 1, total, ca_label);
@@ -58,8 +77,6 @@ pub fn render_cert_body(cert: &CertInfo, lines: &mut Vec<String>, index: usize, 
         top
     });
 
-
-
     add_row(lines, "Subject:", &cert.subject, "", use_color);
     add_row(lines, "Issuer:", &cert.issuer, colors::DIM, use_color);
     add_row(
@@ -67,7 +84,7 @@ pub fn render_cert_body(cert: &CertInfo, lines: &mut Vec<String>, index: usize, 
         "Serial:",
         &truncate_hex(&cert.serial_hex, 24),
         colors::DIM,
-        use_color
+        use_color,
     );
 
     // Empty line
@@ -134,11 +151,12 @@ pub fn render_cert_body(cert: &CertInfo, lines: &mut Vec<String>, index: usize, 
         "SHA-256:",
         &truncate_hex(&cert.sha256_fingerprint, 24),
         colors::DIM,
-        use_color
+        use_color,
     );
 }
 
-pub fn render_cert_bottom(lines: &mut Vec<String>, use_color: bool) {
+// Render the bottom (footer) of a certificate's box
+fn render_cert_bottom(lines: &mut Vec<String>, use_color: bool) {
     // Bottom border
     let bottom = format!(
         "{}{}{}",
@@ -153,8 +171,8 @@ pub fn render_cert_bottom(lines: &mut Vec<String>, use_color: bool) {
     });
 }
 
-// Content rows
-pub fn add_row (lines: &mut Vec<String>, label: &str, value: &str, color: &str, use_color: bool) -> () {
+// Add a row to content
+fn add_row(lines: &mut Vec<String>, label: &str, value: &str, color: &str, use_color: bool) {
     let content = format!("  {:<20}  {}", label, value);
     let pad = WIDTH.saturating_sub(content.len());
 

--- a/src/output/terminal.rs
+++ b/src/output/terminal.rs
@@ -1,15 +1,49 @@
-use crate::cert::CertInfo;
+use crate::cert::{CertInfo, VerboseCert};
 use crate::output::{box_chars, colors, expiry_display};
+
+const WIDTH: usize = 72;
 
 /// Render a certificate in a beautiful box
 pub fn render_cert(cert: &CertInfo, index: usize, total: usize, use_color: bool) -> String {
     let mut lines = Vec::new();
-    let width: usize = 56;
 
+    render_cert_body(cert, &mut lines, index, total, use_color);
+    render_cert_bottom(&mut lines, use_color);
+
+    lines.join("\n")
+}
+
+pub fn render_verbose_cert(cert: &VerboseCert, index: usize, total: usize, use_color: bool) -> String {
+    let mut lines = Vec::new();
+
+    render_cert_body(&cert.base_cert, &mut lines, index, total, use_color);
+
+    for extension in &cert.extensions {
+        // Header
+        lines.push("".to_string());
+        add_row(&mut lines, extension.0.as_str(), "", colors::CYAN, use_color);
+
+        // Content
+        for content in extension.1 {
+            add_row(
+                &mut lines,
+                format!("  {}:", content.0).as_str(),
+                content.1.as_str(),
+                colors::DIM,
+                use_color
+            );
+        }
+    }
+    render_cert_bottom(&mut lines, use_color);
+
+    lines.join("\n")
+}
+
+pub fn render_cert_body(cert: &CertInfo, lines: &mut Vec<String>, index: usize, total: usize, use_color: bool) -> () {
     // Header
     let ca_label = if cert.is_ca { " (CA)" } else { "" };
     let header = format!(" Certificate {} of {}{} ", index + 1, total, ca_label);
-    let padding = width.saturating_sub(header.len() + 2);
+    let padding = WIDTH.saturating_sub(header.len() + 2);
     let top = format!(
         "{}{}{}{}{}",
         box_chars::TOP_LEFT,
@@ -24,49 +58,23 @@ pub fn render_cert(cert: &CertInfo, index: usize, total: usize, use_color: bool)
         top
     });
 
-    // Content rows
-    let add_row = |lines: &mut Vec<String>, label: &str, value: &str, color: &str| {
-        let content = format!("  {:<10}{}", label, value);
-        let pad = width.saturating_sub(content.len());
-        let row = format!(
-            "{}{}{} {}",
-            box_chars::VERTICAL,
-            content,
-            " ".repeat(pad),
-            box_chars::VERTICAL,
-        );
-        if use_color && !color.is_empty() {
-            let padding = " ".repeat(pad);
-            lines.push(format!(
-                "{}{}{}{} {}{}{}{}",
-                colors::CYAN,
-                box_chars::VERTICAL,
-                color,
-                content,
-                colors::CYAN,
-                padding,
-                box_chars::VERTICAL,
-                colors::RESET,
-            ));
-        } else {
-            lines.push(row);
-        }
-    };
 
-    add_row(&mut lines, "Subject:", &cert.subject, "");
-    add_row(&mut lines, "Issuer:", &cert.issuer, colors::DIM);
+
+    add_row(lines, "Subject:", &cert.subject, "", use_color);
+    add_row(lines, "Issuer:", &cert.issuer, colors::DIM, use_color);
     add_row(
-        &mut lines,
+        lines,
         "Serial:",
         &truncate_hex(&cert.serial_hex, 24),
         colors::DIM,
+        use_color
     );
 
     // Empty line
     let empty = format!(
         "{}{} {}",
         box_chars::VERTICAL,
-        " ".repeat(width),
+        " ".repeat(WIDTH),
         box_chars::VERTICAL,
     );
     lines.push(if use_color {
@@ -81,7 +89,7 @@ pub fn render_cert(cert: &CertInfo, index: usize, total: usize, use_color: bool)
         cert.not_before.format("%Y-%m-%d"),
         cert.not_after.format("%Y-%m-%d"),
     );
-    add_row(&mut lines, "Valid:", &valid_range, "");
+    add_row(lines, "Valid:", &valid_range, "", use_color);
 
     // Expiry bar
     let expiry = expiry_display(cert.days_remaining(), use_color);
@@ -104,7 +112,7 @@ pub fn render_cert(cert: &CertInfo, index: usize, total: usize, use_color: bool)
     });
 
     // Key info
-    add_row(&mut lines, "Key:", &cert.key_description(), "");
+    add_row(lines, "Key:", &cert.key_description(), "", use_color);
 
     // SANs
     if !cert.sans.is_empty() {
@@ -117,22 +125,25 @@ pub fn render_cert(cert: &CertInfo, index: usize, total: usize, use_color: bool)
                 cert.sans.len() - 2
             )
         };
-        add_row(&mut lines, "SANs:", &sans_display, "");
+        add_row(lines, "SANs:", &sans_display, "", use_color);
     }
 
     // Fingerprint
     add_row(
-        &mut lines,
+        lines,
         "SHA-256:",
         &truncate_hex(&cert.sha256_fingerprint, 24),
         colors::DIM,
+        use_color
     );
+}
 
+pub fn render_cert_bottom(lines: &mut Vec<String>, use_color: bool) {
     // Bottom border
     let bottom = format!(
         "{}{}{}",
         box_chars::BOTTOM_LEFT,
-        box_chars::HORIZONTAL.repeat(width + 2),
+        box_chars::HORIZONTAL.repeat(WIDTH + 2),
         box_chars::BOTTOM_RIGHT,
     );
     lines.push(if use_color {
@@ -140,8 +151,37 @@ pub fn render_cert(cert: &CertInfo, index: usize, total: usize, use_color: bool)
     } else {
         bottom
     });
+}
 
-    lines.join("\n")
+// Content rows
+pub fn add_row (lines: &mut Vec<String>, label: &str, value: &str, color: &str, use_color: bool) -> () {
+    let content = format!("  {:<20}  {}", label, value);
+    let pad = WIDTH.saturating_sub(content.len());
+
+    let row = format!(
+        "{}{}{} {}",
+        box_chars::VERTICAL,
+        content,
+        " ".repeat(pad),
+        box_chars::VERTICAL,
+    );
+
+    if use_color && !color.is_empty() {
+        let padding = " ".repeat(pad);
+        lines.push(format!(
+            "{}{}{}{} {}{}{}{}",
+            colors::CYAN,
+            box_chars::VERTICAL,
+            color,
+            content,
+            colors::CYAN,
+            padding,
+            box_chars::VERTICAL,
+            colors::RESET,
+        ));
+    } else {
+        lines.push(row);
+    }
 }
 
 /// Render the "signed by" arrow between certs


### PR DESCRIPTION
## What does this PR do?

Closes #19: adds a `--verbose` flag which parses and renders all present x509 extensions when present on `inspect`.

To do this, adds a new struct `VerboseCert` which aggregates `CertInfo`.

When the verbose flag is triggered, processing splits from the normal pipeline in `inspect::run` and follows a parallel process.

Additionally, in `terminal`, the existing rendering functions have been split into `render_cert_body` which renders the header and body of the box and `render_cert_bottom` which renders the footer/bottom of the box.

## How to test

Execute `sslx inspect --verbose` or `cargo run --package sslx --bin sslx -- --verbose inspect [FILE]`

## Checklist
- [x] `cargo test` passes
- [x] `cargo clippy` clean
- [x] `cargo fmt` applied
